### PR TITLE
Add promptware prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+knowledge_base.json
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 # my-first-repo
-This is my first repository to learn GitHub.
+This repository contains a simple demonstration of a concept called **promptware**. Promptware is a small tool that keeps track of tasks and uses AI to break each task down into actionable steps.
+
+## Getting Started
+
+The example script `promptware.py` stores tasks in `knowledge_base.json` and communicates with the OpenAI API to generate step-by-step instructions.
+
+### Installation
+
+1. Install the requirements:
+   ```bash
+   pip install openai
+   ```
+2. Set your OpenAI API key in the environment:
+   ```bash
+   export OPENAI_API_KEY=your_key_here
+   ```
+
+### Usage
+
+Add a new task:
+```bash
+python promptware.py add "Build a personal website"
+```
+
+Process pending tasks and generate steps for each task:
+```bash
+python promptware.py process
+```
+
+View tasks and their status:
+```bash
+python promptware.py view
+```
+
+The script will ask OpenAI to break down tasks into small steps, print the steps, and wait for you to mark them as complete.

--- a/promptware.py
+++ b/promptware.py
@@ -1,0 +1,100 @@
+import argparse
+import json
+import os
+from pathlib import Path
+
+import openai
+
+KNOWLEDGE_BASE = Path("knowledge_base.json")
+
+
+def load_kb():
+    if KNOWLEDGE_BASE.exists():
+        with open(KNOWLEDGE_BASE, "r") as f:
+            return json.load(f)
+    return {"tasks": []}
+
+
+def save_kb(kb):
+    with open(KNOWLEDGE_BASE, "w") as f:
+        json.dump(kb, f, indent=2)
+
+
+def add_task(description: str):
+    kb = load_kb()
+    task_id = len(kb["tasks"]) + 1
+    kb["tasks"].append({
+        "id": task_id,
+        "description": description,
+        "steps": [],
+        "status": "pending",
+    })
+    save_kb(kb)
+    print(f"Added task {task_id}: {description}")
+
+
+def breakdown_task(task: dict, client: openai.OpenAI) -> str:
+    prompt = (
+        "Break down the following task into a numbered list of actionable steps\n\n"
+        f"Task: {task['description']}"
+    )
+    response = client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    steps_text = response.choices[0].message.content.strip()
+    task["steps"] = [s.strip() for s in steps_text.split("\n") if s.strip()]
+    return steps_text
+
+
+def process_tasks(client: openai.OpenAI):
+    kb = load_kb()
+    for task in kb["tasks"]:
+        if task["status"] == "pending":
+            print(f"Processing task {task['id']}: {task['description']}")
+            steps = breakdown_task(task, client)
+            print("Suggested steps:\n" + steps)
+            input("Press enter when task is done...")
+            task["status"] = "done"
+    save_kb(kb)
+    print("All pending tasks processed.")
+
+
+def view_tasks():
+    kb = load_kb()
+    for task in kb["tasks"]:
+        print(f"[{task['status']}] {task['id']}: {task['description']}")
+        for step in task.get("steps", []):
+            print(f"  - {step}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple promptware demo")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    add_p = subparsers.add_parser("add", help="Add a new task")
+    add_p.add_argument("description", help="Task description")
+
+    subparsers.add_parser("process", help="Process pending tasks")
+    subparsers.add_parser("view", help="View all tasks")
+
+    args = parser.parse_args()
+
+    if args.command == "add":
+        add_task(args.description)
+        return
+
+    if args.command == "process":
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise SystemExit(
+                "OPENAI_API_KEY environment variable is required for processing tasks"
+            )
+        client = openai.OpenAI(api_key=api_key)
+        process_tasks(client)
+    elif args.command == "view":
+        view_tasks()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a simple promptware script that stores tasks in a knowledge base
- update README with instructions for installing and running the demo
- ignore runtime artifacts

## Testing
- `pytest -q`
- `python promptware.py --help`
- `python promptware.py view`
- `python promptware.py process` *(fails: OPENAI_API_KEY environment variable is required for processing tasks)*

------
https://chatgpt.com/codex/tasks/task_e_683ffb9a3c348325a01a668a570d9c60